### PR TITLE
Added trailing: false to debounce options, to prevent flickering

### DIFF
--- a/gmap-custom-marker.vue
+++ b/gmap-custom-marker.vue
@@ -151,7 +151,7 @@ export default {
         // We'll use these coordinates to resize the div.
         this.setPosition(self.position);
 
-      }, 10);
+      }, 10, { trailing: false });
 
       // The onRemove() method will be called automatically from the API if
       // we ever set the overlay's map property to 'null'.


### PR DESCRIPTION
To prevent the custom marker from flickering when you stop dragging the map (as seen here: https://codesandbox.io/s/4w642qo17w)