### PR TITLE
Only redraw overlay after map is loaded

### DIFF
--- a/gmap-custom-marker.vue
+++ b/gmap-custom-marker.vue
@@ -12,7 +12,7 @@ export default {
   props: ['marker', 'onClick'],
   watch: {
     marker: function (val) {
-      this.$overlay.draw();
+     this.$mapPromise.then(map => this.$overlay.draw());
     },
   },
   provide: function () {


### PR DESCRIPTION
Thanks for making this super useful component! I have a project using this and I ran into an issue with this error:

```
[Vue warn]: Error in callback for watcher "marker": "TypeError: Cannot read property 'draw' of undefined"
```
When I would update some filters that would recenter/draw the map. This seems to fix that.