### PR TITLE
set z-index from prop

### DIFF
--- a/gmap-custom-marker.vue
+++ b/gmap-custom-marker.vue
@@ -23,6 +23,10 @@ export default {
     alignment: {
       type: String,
       default: "top"
+    },
+    zIndex: {
+      type: Number,
+      default: 50
     }
   },
   data () {
@@ -110,7 +114,7 @@ export default {
           const panes = this.getPanes()
           div.style.position = 'absolute'
           div.style.display = 'inline-block'
-          div.style.zIndex = 50
+          div.style.zIndex = self.zIndex
           panes.overlayLayer.appendChild(div)
           panes.overlayMouseTarget.appendChild(div)
         }


### PR DESCRIPTION
This allows you to set the z-index from the parent component.

For example, it can be used to make sure that the marker you're hovering is placed on top of any other markers. Something like this:

```
<gmap-custom-marker
    v-for="marker in myMarkers"
    :key="`${asset.id}${assetHover}`"
    :marker="{ latitude: asset.lat, longitude: asset.lng }"
    :z-index="asset.id == assetHover ? 51 : 50"
    @mouseover.native="assetHover = asset.id"
>
    <my-component />
</gmap-custom-marker>
```
