### PR TITLE
prevent adding marker twice to `$clusterObject`

### DIFF
--- a/gmap-custom-marker.vue
+++ b/gmap-custom-marker.vue
@@ -43,10 +43,11 @@ export default {
   },
   methods: {
     afterCreate(inst) {
-      if (this.$clusterPromise) {
+      if (this.$clusterPromise && !this.isMarkerAdded) {
         this.$clusterPromise.then(co => {
           co.addMarker(inst);
           this.$clusterObject = co;
+          this.isMarkerAdded = true;
         });
       }
     }


### PR DESCRIPTION
I found a bug when I used this marker inside cluster component (`vue2-google-maps/dist/components/cluster`).

If some markers are close enough, cluster removes these markers and replace to a cluster.
In a few seconds I zoom map, the cluster component add them into map again.
I mean, it calls `onAdd()` method twice and, to make it worse,  makes the first one unremovable.

So I added `isMarkerAdded` flag to prevent this behavior.
Please check it out.