### PR TITLE
Check if we have an overlay before using the object

### DIFF
--- a/gmap-custom-marker.vue
+++ b/gmap-custom-marker.vue
@@ -198,8 +198,10 @@
       if (this.$clusterObject) {
         this.$clusterObject.removeMarker(this.$overlay, true);
       } else {
-        this.$overlay.setMap(null);
-        this.$overlay = undefined;
+	if (this.$overlay) {
+          this.$overlay.setMap(null);
+          this.$overlay = undefined;
+	}
       }
     }
   };


### PR DESCRIPTION
I've run in to a situation with vuex and vuex-persist that lead to markers being created and destroyed in the same tick. When that happens, the $overlay object doesn't exist when destroyed() gets called.